### PR TITLE
Shutdown algo children

### DIFF
--- a/algos/starter-algo/gamelib/util.py
+++ b/algos/starter-algo/gamelib/util.py
@@ -14,7 +14,8 @@ def get_command():
         # Game parent process terminated so exit
         exit()
     if ret == "":
-        # Happens if parent game process dies, so exit for cleanup
+        # Happens if parent game process dies, so exit for cleanup, 
+        # Don't change or starter-algo process won't exit even though the game has closed
         debug_write("Got EOF, parent game process must have died, exiting for cleanup")
         exit()
     return ret

--- a/algos/starter-algo/gamelib/util.py
+++ b/algos/starter-algo/gamelib/util.py
@@ -13,6 +13,10 @@ def get_command():
     except EOFError:
         # Game parent process terminated so exit
         exit()
+    if ret == "":
+        # Happens if parent game process dies, so exit for cleanup
+        debug_write("Got EOF, parent game process must have died, exiting for cleanup")
+        exit()
     return ret
 
 def send_command(cmd):

--- a/algos/starter-algo/gamelib/util.py
+++ b/algos/starter-algo/gamelib/util.py
@@ -12,6 +12,7 @@ def get_command():
         ret = sys.stdin.readline()
     except EOFError:
         # Game parent process terminated so exit
+        debug_write("Got EOF, parent game process must have died, exiting for cleanup")
         exit()
     if ret == "":
         # Happens if parent game process dies, so exit for cleanup, 

--- a/algos/starter-algo/gamelib/util.py
+++ b/algos/starter-algo/gamelib/util.py
@@ -8,7 +8,12 @@ def get_command():
     """Gets input from stdin
 
     """
-    return sys.stdin.readline()
+    try:
+        ret = sys.stdin.readline()
+    except EOFError:
+        # Game parent process terminated so exit
+        exit()
+    return ret
 
 def send_command(cmd):
     """Sends your turn to standard output.


### PR DESCRIPTION
Previously on windows and linux if you terminate a game early the algo processes stay alive. This update makes it so the starter-algo checks to see if the parent process died by checking for EOF or "" in stdin which occurs if the parent process dies. 