### PR TITLE
Make getting unit information easier, and spawn units at full stability

### DIFF
--- a/rust-algo/algo/src/map.rs
+++ b/rust-algo/algo/src/map.rs
@@ -369,6 +369,11 @@ pub struct GameState {
 }
 
 impl GameState {
+    /// Get the atlas, as a normal reference
+    pub fn atlas(&self) -> &UnitTypeAtlas {
+        &self.atlas
+    }
+
     /// Get the referenced map, which may be mutated by move builder operations.
     pub fn map(&self) -> &Map {
         &self.map

--- a/rust-algo/algo/src/map.rs
+++ b/rust-algo/algo/src/map.rs
@@ -1,7 +1,7 @@
 
 use coords::Coords;
 use super::units::*;
-use super::messages::{PlayerId, FrameData, Config, frame};
+use super::messages::{PlayerId, FrameData, Config, frame, config::UnitInformation};
 use super::bounds::{MAP_BOUNDS, BOARD_SIZE, MapEdge};
 use super::grid::Grid;
 use super::pathfinding::StartedAtWall;
@@ -514,22 +514,26 @@ impl<'a> StateTile<'a> {
 
         match unit_type {
             SpawnableUnitType::Firewall(unit_type) => {
-                let unit = Unit {
-                    unit_type,
-                    stability: 1.0,
-                    id: None,
-                    owner: PlayerId::Player1
-                };
-                *self.builder.map.walls.get_mut(coords).unwrap() = Some(unit);
+                if let UnitInformation::Wall{stability,..} = self.builder.atlas.type_info(unit_type.into()) {
+                    let unit = Unit {
+                        unit_type,
+                        stability: *stability,
+                        id: None,
+                        owner: PlayerId::Player1
+                    };
+                    *self.builder.map.walls.get_mut(coords).unwrap() = Some(unit);
+                }
             },
             SpawnableUnitType::Info(unit_type) => {
-                let unit = Unit {
-                    unit_type,
-                    stability: 1.0,
-                    id: None,
-                    owner: PlayerId::Player1
-                };
-                self.builder.map.info.get_mut(coords).unwrap().push(unit);
+                if let UnitInformation::Data{stability,..} = self.builder.atlas.type_info(unit_type.into()) {
+                    let unit = Unit {
+                        unit_type,
+                        stability: *stability,
+                        id: None,
+                        owner: PlayerId::Player1
+                    };
+                    self.builder.map.info.get_mut(coords).unwrap().push(unit);
+                }
             }
         }
 

--- a/rust-algo/algo/src/map.rs
+++ b/rust-algo/algo/src/map.rs
@@ -519,7 +519,7 @@ impl<'a> StateTile<'a> {
 
         match unit_type {
             SpawnableUnitType::Firewall(unit_type) => {
-                if let UnitInformation::Wall{stability,..} = self.builder.atlas.type_info(unit_type.into()) {
+                if let UnitInformation::Wall { stability, .. } = self.builder.atlas.type_info(unit_type.into()) {
                     let unit = Unit {
                         unit_type,
                         stability: *stability,
@@ -527,10 +527,10 @@ impl<'a> StateTile<'a> {
                         owner: PlayerId::Player1
                     };
                     *self.builder.map.walls.get_mut(coords).unwrap() = Some(unit);
-                }
+                } else { panic!("A SpawnableUnitType::Firewall isn't a UnitInformation::Wall - is something wrong with the Atlas?") }
             },
             SpawnableUnitType::Info(unit_type) => {
-                if let UnitInformation::Data{stability,..} = self.builder.atlas.type_info(unit_type.into()) {
+                if let UnitInformation::Data { stability, .. } = self.builder.atlas.type_info(unit_type.into()) {
                     let unit = Unit {
                         unit_type,
                         stability: *stability,
@@ -538,7 +538,7 @@ impl<'a> StateTile<'a> {
                         owner: PlayerId::Player1
                     };
                     self.builder.map.info.get_mut(coords).unwrap().push(unit);
-                }
+                } else { panic!("A SpawnableUnitType::Info isn't a UnitInformation::Data - is something wrong with the Atlas?") }
             }
         }
 

--- a/rust-algo/algo/src/units.rs
+++ b/rust-algo/algo/src/units.rs
@@ -181,6 +181,11 @@ impl UnitTypeAtlas {
         }
     }
 
+    // Get the UnitInformation from a unit type
+    pub fn type_info(&self, unit_type: UnitType) -> &UnitInformation {
+        &self.unit_information[unit_type as u32 as usize]
+    }
+
     /// Convert a unit type integer into a UnitType.
     pub fn type_from_u32(&self, n: u32) -> Option<UnitType> {
         UnitType::into_enum_iter().nth(n as usize)

--- a/rust-algo/algo/src/units.rs
+++ b/rust-algo/algo/src/units.rs
@@ -181,7 +181,7 @@ impl UnitTypeAtlas {
         }
     }
 
-    // Get the UnitInformation from a unit type
+    /// Get the UnitInformation from a unit type
     pub fn type_info(&self, unit_type: UnitType) -> &UnitInformation {
         &self.unit_information[unit_type as u32 as usize]
     }


### PR DESCRIPTION
New functions:
- `GameState::atlas(&self) -> &UnitTypeAtlas`
- `UnitTypeAtlas::type_info(&self, unit_type: UnitType) -> &UnitInformation`