### PR TITLE
error handling for game_state.contains_stationary_unit([0,0])

### DIFF
--- a/python-algo/gamelib/game_state.py
+++ b/python-algo/gamelib/game_state.py
@@ -387,6 +387,8 @@ class GameState:
             True if there is a stationary unit at the location, False otherwise
             
         """
+        if not self.game_map.in_arena_bounds(location):
+            return False
         x, y = map(int, location)
         for unit in self.game_map[x,y]:
             if unit.stationary:


### PR DESCRIPTION
Calling **contains_stationary_unit** with bad coordinates currently gives a not very intutive error

> File "game_state.py", line 391, in contains_stationary_unit
> for unit in self.game_map[x,y]:
> TypeError: 'NoneType' object is not iterable