### PR TITLE
clippy fixes + cargo fmt

### DIFF
--- a/rust-algo/algo/src/bounds.rs
+++ b/rust-algo/algo/src/bounds.rs
@@ -1,4 +1,3 @@
-
 use crate::coords::*;
 use enum_iterator::IntoEnumIterator;
 
@@ -17,6 +16,12 @@ pub struct MapBounds {
     pub arena: [[bool; BOARD_SIZE]; BOARD_SIZE],
 }
 
+impl Default for MapBounds {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl MapBounds {
     /// Compute a cache of the map bounds.
     pub fn new() -> Self {
@@ -24,7 +29,7 @@ impl MapBounds {
             is_on_edge: &mut [[[bool; BOARD_SIZE]; BOARD_SIZE]; 4],
             edge_lists: &mut [[Coords; BOARD_SIZE / 2]; 4],
             edge: MapEdge,
-            calc_coords: impl Fn(usize) -> [usize; 2]
+            calc_coords: impl Fn(usize) -> [usize; 2],
         ) {
             for i in 0..BOARD_SIZE / 2 {
                 let c = calc_coords(i);
@@ -37,40 +42,46 @@ impl MapBounds {
         let mut is_on_edge = [[[false; BOARD_SIZE]; BOARD_SIZE]; 4];
         let mut edge_lists = [[ORIGIN; BOARD_SIZE / 2]; 4];
 
-        populate(&mut is_on_edge, &mut edge_lists, MapEdge::TopRight,
-                       |i| [BOARD_SIZE / 2 + i, BOARD_SIZE - 1 - i]
-        );
-        populate(&mut is_on_edge, &mut edge_lists, MapEdge::TopLeft,
-                       |i| [BOARD_SIZE / 2 - 1 - i, BOARD_SIZE - 1 - i]
-        );
-        populate(&mut is_on_edge, &mut edge_lists, MapEdge::BottomLeft,
-                       |i| [BOARD_SIZE / 2 - 1 - i, i]
-        );
-        populate(&mut is_on_edge, &mut edge_lists, MapEdge::BottomRight,
-                       |i| [BOARD_SIZE / 2 + i, i]
+        populate(&mut is_on_edge, &mut edge_lists, MapEdge::TopRight, |i| {
+            [BOARD_SIZE / 2 + i, BOARD_SIZE - 1 - i]
+        });
+        populate(&mut is_on_edge, &mut edge_lists, MapEdge::TopLeft, |i| {
+            [BOARD_SIZE / 2 - 1 - i, BOARD_SIZE - 1 - i]
+        });
+        populate(&mut is_on_edge, &mut edge_lists, MapEdge::BottomLeft, |i| {
+            [BOARD_SIZE / 2 - 1 - i, i]
+        });
+        populate(
+            &mut is_on_edge,
+            &mut edge_lists,
+            MapEdge::BottomRight,
+            |i| [BOARD_SIZE / 2 + i, i],
         );
 
         let mut arena = [[false; BOARD_SIZE]; BOARD_SIZE];
 
+        #[allow(clippy::needless_range_loop)]
         for i in 0..4 {
+            #[allow(clippy::needless_range_loop)]
             for j in 0..BOARD_SIZE {
+                #[allow(clippy::needless_range_loop)]
                 for k in 0..BOARD_SIZE {
                     arena[j][k] |= is_on_edge[i][j][k];
                 }
             }
         }
 
-        for y in 0..BOARD_SIZE {
+        for slice in arena.iter_mut() {
             let mut toggled = false;
-            for x in 0..BOARD_SIZE {
-                if arena[x][y] {
+            for position in slice.iter_mut() {
+                if *position {
                     if toggled {
                         break;
                     } else {
                         toggled = true;
                     }
                 } else if toggled {
-                    arena[x][y] = true;
+                    *position = true;
                 }
             }
         }
@@ -78,26 +89,26 @@ impl MapBounds {
         MapBounds {
             is_on_edge,
             edge_lists,
-            arena
+            arena,
         }
     }
 
     /// Is the given coord in the arena?
     pub fn is_in_arena(&self, coords: Coords) -> bool {
-        coords.x >= 0 &&
-            coords.y >= 0 &&
-            coords.x < BOARD_SIZE as i32 &&
-            coords.y < BOARD_SIZE as i32 &&
-            self.arena[coords.x as usize][coords.y as usize]
+        coords.x >= 0
+            && coords.y >= 0
+            && coords.x < BOARD_SIZE as i32
+            && coords.y < BOARD_SIZE as i32
+            && self.arena[coords.x as usize][coords.y as usize]
     }
 
     /// Is the given coord on the given edge?
     pub fn is_on_edge(&self, edge: MapEdge, coords: Coords) -> bool {
-        coords.x >= 0 &&
-            coords.y >= 0 &&
-            coords.x < BOARD_SIZE as i32 &&
-            coords.y < BOARD_SIZE as i32 &&
-            self.is_on_edge[edge as usize][coords.x as usize][coords.y as usize]
+        coords.x >= 0
+            && coords.y >= 0
+            && coords.x < BOARD_SIZE as i32
+            && coords.y < BOARD_SIZE as i32
+            && self.is_on_edge[edge as usize][coords.x as usize][coords.y as usize]
     }
 
     /// Reference to all the coords on that edge.
@@ -105,7 +116,6 @@ impl MapBounds {
         &self.edge_lists[edge as usize]
     }
 }
-
 
 /// Edge of the map.
 #[repr(usize)]

--- a/rust-algo/algo/src/coords.rs
+++ b/rust-algo/algo/src/coords.rs
@@ -1,15 +1,10 @@
-
 use crate::{
-    messages::serde_util::{
-        SerializeAs,
-        DeserializeAs,
-        RoundNumber,
-    },
-    bounds::{MAP_BOUNDS, MapEdge},
+    bounds::{MapEdge, MAP_BOUNDS},
+    messages::serde_util::{DeserializeAs, RoundNumber, SerializeAs},
 };
 use std::{
+    fmt::{self, Debug, Display, Formatter},
     ops::*,
-    fmt::{self, Debug, Display, Formatter}
 };
 
 use num_traits::cast::ToPrimitive;
@@ -54,10 +49,9 @@ pub const fn xy(x: i32, y: i32) -> Coords {
 /// Macro version of coordinates constructor, for use in initializing constants.
 #[macro_export]
 macro_rules! xy {
-    ($x:expr, $y:expr)=>{ Coords {
-        x: $x,
-        y: $y,
-    }};
+    ($x:expr, $y:expr) => {
+        Coords { x: $x, y: $y }
+    };
 }
 
 /// <0, 0> coordinate constant.
@@ -92,7 +86,6 @@ impl DeserializeAs for Coords {
 ser_as!(Coords);
 deser_as!(Coords);
 
-
 impl Debug for Coords {
     fn fmt(&self, f: &mut Formatter) -> Result<(), fmt::Error> {
         f.write_str(&format!("[{},{}]", self.x, self.y))
@@ -104,7 +97,6 @@ impl Display for Coords {
         f.write_str(&format!("<{},{}>", self.x, self.y))
     }
 }
-
 
 impl<I: ToPrimitive> From<[I; 2]> for Coords {
     fn from(components: [I; 2]) -> Self {
@@ -222,4 +214,3 @@ impl RemAssign<i32> for Coords {
         self.y %= rhs;
     }
 }
-

--- a/rust-algo/algo/src/gameloop.rs
+++ b/rust-algo/algo/src/gameloop.rs
@@ -1,18 +1,11 @@
-
 use crate::{
-    messages::Config,
-    messages::frame::Phase,
     io::GameDataReader,
-    map::{
-        MapState,
-        parse::parse_frame,
-    },
+    map::{parse::parse_frame, MapState},
+    messages::frame::Phase,
+    messages::Config,
 };
 
-use std::{
-    process,
-    sync::Arc,
-};
+use std::{process, sync::Arc};
 
 /// A trait for a simple, single-threaded game loop, which the user can implement and then plug into a
 /// game loop driver to create a working algo.
@@ -37,30 +30,25 @@ pub trait GameLoop {
     fn on_turn(&mut self, config: Arc<Config>, state: &MapState);
 }
 
-
 /// Run a game loop until the game ends and the process exits.
 pub fn run_game_loop(mut game_loop: impl GameLoop) -> ! {
-    let mut io = GameDataReader::new();
+    let mut io = GameDataReader::default();
     let (config, atlas) = io.config().expect("Config error");
     game_loop.initialize(config.clone());
     loop {
         let frame = io.next_frame_any_type().expect("Frame error");
         match frame.turn_info.phase {
             Phase::Deploy => {
-                let map =
-                    parse_frame(config.clone(), frame, atlas.clone())
-                        .expect("Frame error");
+                let map = parse_frame(config.clone(), frame, atlas.clone()).expect("Frame error");
 
                 game_loop.on_turn(config.clone(), &map);
                 map.submit();
-            },
+            }
             Phase::Action => {
-                let map =
-                    parse_frame(config.clone(), frame, atlas.clone())
-                        .expect("Frame error");
+                let map = parse_frame(config.clone(), frame, atlas.clone()).expect("Frame error");
 
                 game_loop.on_action_frame(config.clone(), &map);
-            },
+            }
             Phase::EndGame => {
                 process::exit(0);
             }

--- a/rust-algo/algo/src/grid.rs
+++ b/rust-algo/algo/src/grid.rs
@@ -1,12 +1,8 @@
-
-use crate::{
-    coords::*,
-    bounds::BOARD_SIZE,
-};
+use crate::{bounds::BOARD_SIZE, coords::*};
 
 use std::{
-    mem::{MaybeUninit, ManuallyDrop},
     fmt::{self, Debug, Formatter},
+    mem::{ManuallyDrop, MaybeUninit},
     ops::{Index, IndexMut},
     ptr,
 };
@@ -31,9 +27,9 @@ impl<T> Grid<T> {
 
                     let addr: *mut [[T; BOARD_SIZE]; BOARD_SIZE] = data.as_mut_ptr();
                     let addr: *mut [T; BOARD_SIZE] = addr as _;
-                    let addr: *mut [T; BOARD_SIZE] = addr.offset(x as isize);
+                    let addr: *mut [T; BOARD_SIZE] = addr.add(x);
                     let addr: *mut T = addr as _;
-                    let addr: *mut T = addr.offset(y as isize);
+                    let addr: *mut T = addr.add(y);
 
                     ptr::write(addr, value);
                 }
@@ -42,9 +38,7 @@ impl<T> Grid<T> {
             let data: [[T; BOARD_SIZE]; BOARD_SIZE] =
                 MaybeUninit::assume_init(ManuallyDrop::into_inner(data));
 
-            Grid {
-                data
-            }
+            Grid { data }
         }
     }
 
@@ -81,14 +75,12 @@ impl<T> IndexMut<Coords> for Grid<T> {
 
 impl<T: Debug> Debug for Grid<T> {
     fn fmt(&self, f: &mut Formatter) -> Result<(), fmt::Error> {
-        let strings: Grid<String> =
-            Grid::from_generator(|c| format!("{:?}", self.get(c).unwrap()));
+        let strings: Grid<String> = Grid::from_generator(|c| format!("{:?}", self.get(c).unwrap()));
 
         let mut max_len = None;
         for x in 0..BOARD_SIZE {
             for y in 0..BOARD_SIZE {
-                let len = strings.get(Coords::from([x, y])).unwrap()
-                    .chars().collect::<Vec<char>>().len();
+                let len = strings.get(Coords::from([x, y])).unwrap().chars().count();
                 if let Some(max) = max_len {
                     if len > max {
                         max_len = Some(len);
@@ -107,12 +99,12 @@ impl<T: Debug> Debug for Grid<T> {
             for x in 0..BOARD_SIZE {
                 let elem = strings.get(Coords::from([x, y])).unwrap();
                 builder.push_str(elem);
-                let elem_len = elem.chars().collect::<Vec<char>>().len();
+                let elem_len = elem.chars().count();
                 for _ in 0..max_len - elem_len {
                     builder.push(' ');
                 }
                 if x < BOARD_SIZE - 1 {
-                    builder.push_str(",");
+                    builder.push(',');
                 }
             }
             builder.push(']');

--- a/rust-algo/algo/src/lib.rs
+++ b/rust-algo/algo/src/lib.rs
@@ -1,11 +1,10 @@
-
 #[macro_use]
 extern crate lazy_static;
-extern crate serde;
-extern crate serde_json;
 extern crate enum_iterator;
 extern crate num_enum;
 extern crate num_traits;
+extern crate serde;
+extern crate serde_json;
 
 #[macro_use]
 pub mod messages;
@@ -13,24 +12,24 @@ pub mod units;
 #[macro_use]
 pub mod map;
 pub mod bounds;
+pub mod coords;
+pub mod gameloop;
 pub mod grid;
 pub mod io;
-pub mod gameloop;
 pub mod pathfinding;
-pub mod coords;
 
 pub use enum_iterator::IntoEnumIterator;
 
 /// Common re-exports.
 pub mod prelude {
-    pub use super::units::*;
-    pub use super::map::*;
     pub use super::bounds::*;
-    pub use super::io::*;
-    pub use super::gameloop::*;
-    pub use super::messages::{Config, PlayerId};
-    pub use super::grid::Grid;
     pub use super::coords::*;
-    pub use std::sync::Arc;
+    pub use super::gameloop::*;
+    pub use super::grid::Grid;
+    pub use super::io::*;
+    pub use super::map::*;
+    pub use super::messages::{Config, PlayerId};
+    pub use super::units::*;
     pub use enum_iterator::IntoEnumIterator;
+    pub use std::sync::Arc;
 }

--- a/rust-algo/algo/src/map/parse.rs
+++ b/rust-algo/algo/src/map/parse.rs
@@ -1,4 +1,3 @@
-
 use super::*;
 
 pub fn parse_frame(
@@ -6,15 +5,11 @@ pub fn parse_frame(
     frame: Box<FrameData>,
     atlas: Arc<UnitTypeAtlas>,
 ) -> Result<MapState, MapParseError> {
-// create the grids
-    let mut walls: Grid<Option<Unit<StructureUnitType>>> =
-        Grid::from_generator(|_| None);
-    let mut remove: Grid<Option<Unit<RemoveUnitType>>> =
-        Grid::from_generator(|_| None);
-    let mut upgrade: Grid<Option<Unit<UpgradeUnitType>>> =
-        Grid::from_generator(|_| None);
-    let mut mobile: Grid<Vec<Unit<MobileUnitType>>> =
-        Grid::from_generator(|_| Vec::new());
+    // create the grids
+    let mut walls: Grid<Option<Unit<StructureUnitType>>> = Grid::from_generator(|_| None);
+    let mut remove: Grid<Option<Unit<RemoveUnitType>>> = Grid::from_generator(|_| None);
+    let mut upgrade: Grid<Option<Unit<UpgradeUnitType>>> = Grid::from_generator(|_| None);
+    let mut mobile: Grid<Vec<Unit<MobileUnitType>>> = Grid::from_generator(|_| Vec::new());
 
     // for each player
     for player in PlayerId::into_enum_iter() {
@@ -31,7 +26,8 @@ pub fn parse_frame(
                 MobileUnitType::Interceptor => &units.interceptor,
             };
             for unit_data in unit_data_vec {
-                mobile.get_mut(unit_data.coords)
+                mobile
+                    .get_mut(unit_data.coords)
                     .ok_or(MapParseError::UnitInIllegalPosition(unit_data.coords))?
                     .push(Unit {
                         unit_type,
@@ -50,7 +46,8 @@ pub fn parse_frame(
                 StructureUnitType::Turret => &units.turret,
             };
             for unit_data in unit_data_vec {
-                let slot: &mut Option<Unit<StructureUnitType>> = walls.get_mut(unit_data.coords)
+                let slot: &mut Option<Unit<StructureUnitType>> = walls
+                    .get_mut(unit_data.coords)
                     .ok_or(MapParseError::UnitInIllegalPosition(unit_data.coords))?;
                 if slot.is_some() {
                     return Err(MapParseError::MultipleWallsSamePosition(unit_data.coords));
@@ -59,14 +56,15 @@ pub fn parse_frame(
                     unit_type,
                     health: unit_data.stability,
                     id: Some(unit_data.unit_id.clone()),
-                    owner: player
+                    owner: player,
                 });
             }
         }
 
         // fill in the remove units
         for unit_data in &units.remove {
-            let slot: &mut Option<Unit<RemoveUnitType>> = remove.get_mut(unit_data.coords)
+            let slot: &mut Option<Unit<RemoveUnitType>> = remove
+                .get_mut(unit_data.coords)
                 .ok_or(MapParseError::UnitInIllegalPosition(unit_data.coords))?;
             if slot.is_some() {
                 return Err(MapParseError::MultipleRemovesSamePosition(unit_data.coords));
@@ -75,26 +73,27 @@ pub fn parse_frame(
                 unit_type: RemoveUnitType,
                 health: unit_data.stability,
                 id: Some(unit_data.unit_id.clone()),
-                owner: player
+                owner: player,
             });
         }
 
         // fill in the upgrade units
         for unit_data in &units.upgrade {
-            let slot: &mut Option<Unit<UpgradeUnitType>> = upgrade.get_mut(unit_data.coords)
+            let slot: &mut Option<Unit<UpgradeUnitType>> = upgrade
+                .get_mut(unit_data.coords)
                 .ok_or(MapParseError::UnitInIllegalPosition(unit_data.coords))?;
             if slot.is_some() {
-                return Err(MapParseError::MultipleUpgradesSamePosition(unit_data.coords));
+                return Err(MapParseError::MultipleUpgradesSamePosition(
+                    unit_data.coords,
+                ));
             }
             *slot = Some(Unit {
                 unit_type: UpgradeUnitType,
                 health: unit_data.stability,
                 id: Some(unit_data.unit_id.clone()),
-                owner: player
+                owner: player,
             });
         }
-
-
     }
 
     let inner = MapStateInner {
@@ -123,10 +122,7 @@ pub fn parse_frame(
         }
     });
 
-    Ok(MapState {
-        inner,
-        tile_grid,
-    })
+    Ok(MapState { inner, tile_grid })
 }
 
 /// All the ways in which a map can fail to parse from a string.

--- a/rust-algo/algo/src/messages/config.rs
+++ b/rust-algo/algo/src/messages/config.rs
@@ -1,6 +1,5 @@
-
-use serde::{Deserialize};
 use enum_iterator::IntoEnumIterator;
+use serde::Deserialize;
 
 #[derive(Debug, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
@@ -61,5 +60,5 @@ pub struct Resources {
     pub cores_per_round: f32,
     pub starting_bits: f32,
     pub bit_decay_per_round: f32,
-    pub starting_cores: f32
+    pub starting_cores: f32,
 }

--- a/rust-algo/algo/src/messages/frame.rs
+++ b/rust-algo/algo/src/messages/frame.rs
@@ -1,8 +1,7 @@
-use crate::coords::*;
 use super::PlayerId;
-use serde::Deserialize;
+use crate::coords::*;
 use enum_iterator::IntoEnumIterator;
-
+use serde::Deserialize;
 
 use super::serde_util::{DeserializeAs, RoundNumber};
 
@@ -17,12 +16,9 @@ pub struct TurnInfo {
 impl DeserializeAs for TurnInfo {
     type Model = (Phase, RoundNumber, RoundNumber, RoundNumber);
 
-    fn from_model((
-                      phase,
-                      turn_number,
-                      action_phase_frame_number,
-                      total_number_frames,
-                  ): Self::Model) -> Self {
+    fn from_model(
+        (phase, turn_number, action_phase_frame_number, total_number_frames): Self::Model,
+    ) -> Self {
         TurnInfo {
             phase,
             turn_number: turn_number.int(),
@@ -34,12 +30,11 @@ impl DeserializeAs for TurnInfo {
 
 deser_as!(TurnInfo);
 
-
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, IntoEnumIterator)]
 pub enum Phase {
     Deploy,
     Action,
-    EndGame
+    EndGame,
 }
 
 serde_enum_from_int!(Phase, {
@@ -56,12 +51,15 @@ pub struct PlayerStats {
     pub time_taken_last_turn_millis: f32,
 }
 
-deser_as_tuple!(PlayerStats, (
-    integrity: f64,
-    cores: f32,
-    bits: f32,
-    time_taken_last_turn_millis: f32,
-));
+deser_as_tuple!(
+    PlayerStats,
+    (
+        integrity: f64,
+        cores: f32,
+        bits: f32,
+        time_taken_last_turn_millis: f32,
+    )
+);
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct PlayerUnit {
@@ -69,7 +67,6 @@ pub struct PlayerUnit {
     pub stability: f32,
     pub unit_id: String,
 }
-
 
 impl DeserializeAs for PlayerUnit {
     type Model = (i32, i32, f32, String);
@@ -85,7 +82,6 @@ impl DeserializeAs for PlayerUnit {
 
 deser_as!(PlayerUnit);
 
-
 #[derive(Debug, Clone, PartialEq)]
 pub struct PlayerUnits {
     pub wall: Vec<PlayerUnit>,
@@ -98,17 +94,19 @@ pub struct PlayerUnits {
     pub upgrade: Vec<PlayerUnit>,
 }
 
-deser_as_tuple!(PlayerUnits, (
-    wall: Vec<PlayerUnit>,
-    support: Vec<PlayerUnit>,
-    turret: Vec<PlayerUnit>,
-    scout: Vec<PlayerUnit>,
-    demolisher: Vec<PlayerUnit>,
-    interceptor: Vec<PlayerUnit>,
-    remove: Vec<PlayerUnit>,
-    upgrade: Vec<PlayerUnit>,
-));
-
+deser_as_tuple!(
+    PlayerUnits,
+    (
+        wall: Vec<PlayerUnit>,
+        support: Vec<PlayerUnit>,
+        turret: Vec<PlayerUnit>,
+        scout: Vec<PlayerUnit>,
+        demolisher: Vec<PlayerUnit>,
+        interceptor: Vec<PlayerUnit>,
+        remove: Vec<PlayerUnit>,
+        upgrade: Vec<PlayerUnit>,
+    )
+);
 
 #[derive(Debug, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
@@ -120,7 +118,6 @@ pub struct EndStats {
     pub frames: i32,
     pub winner: Winner,
 }
-
 
 #[derive(Copy, Deserialize, Debug, Clone, PartialEq)]
 pub struct PlayerEndStats {
@@ -134,12 +131,11 @@ pub struct PlayerEndStats {
     pub total_computation_time: f32,
 }
 
-
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, IntoEnumIterator)]
 pub enum Winner {
     Tie,
     Player1,
-    Player2
+    Player2,
 }
 
 serde_enum_from_int!(Winner, {
@@ -147,7 +143,6 @@ serde_enum_from_int!(Winner, {
     1 => Winner::Player1,
     2 => Winner::Player2,
 });
-
 
 #[derive(Debug, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
@@ -164,7 +159,6 @@ pub struct Events {
     pub spawn: Vec<SpawnEvent>,
 }
 
-
 #[derive(Debug, Clone, PartialEq)]
 pub struct AttackEvent {
     pub source: Coords,
@@ -176,16 +170,18 @@ pub struct AttackEvent {
     pub source_player: PlayerId,
 }
 
-deser_as_tuple!(AttackEvent, (
-    source: Coords,
-    target: Coords,
-    damage: f32,
-    attacker_type: u8,
-    source_unit_id: String,
-    target_unit_id: String,
-    source_player: PlayerId,
-));
-
+deser_as_tuple!(
+    AttackEvent,
+    (
+        source: Coords,
+        target: Coords,
+        damage: f32,
+        attacker_type: u8,
+        source_unit_id: String,
+        target_unit_id: String,
+        source_player: PlayerId,
+    )
+);
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct BreachEvent {
@@ -196,14 +192,16 @@ pub struct BreachEvent {
     pub unit_owner: PlayerId,
 }
 
-deser_as_tuple!(BreachEvent, (
-    coords: Coords,
-    damage: f32,
-    breacher_type: u8,
-    breacher_id: String,
-    unit_owner: PlayerId,
-));
-
+deser_as_tuple!(
+    BreachEvent,
+    (
+        coords: Coords,
+        damage: f32,
+        breacher_type: u8,
+        breacher_id: String,
+        unit_owner: PlayerId,
+    )
+);
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct DamageEvent {
@@ -214,14 +212,16 @@ pub struct DamageEvent {
     pub unit_owner: PlayerId,
 }
 
-deser_as_tuple!(DamageEvent, (
-    coords: Coords,
-    damage: f32,
-    damager_type: u8,
-    damager_id: String,
-    unit_owner: PlayerId,
-));
-
+deser_as_tuple!(
+    DamageEvent,
+    (
+        coords: Coords,
+        damage: f32,
+        damager_type: u8,
+        damager_id: String,
+        unit_owner: PlayerId,
+    )
+);
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct DeathEvent {
@@ -232,14 +232,16 @@ pub struct DeathEvent {
     pub is_self_removal: bool,
 }
 
-deser_as_tuple!(DeathEvent, (
-    coords: Coords,
-    destroyed_unit_type: u8,
-    destroyed_unit_id: String,
-    unit_owner: PlayerId,
-    is_self_removal: bool,
-));
-
+deser_as_tuple!(
+    DeathEvent,
+    (
+        coords: Coords,
+        destroyed_unit_type: u8,
+        destroyed_unit_id: String,
+        unit_owner: PlayerId,
+        is_self_removal: bool,
+    )
+);
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct MeleeEvent {
@@ -251,15 +253,17 @@ pub struct MeleeEvent {
     pub attacker_player_id: PlayerId,
 }
 
-deser_as_tuple!(MeleeEvent, (
-    attacker_location: Coords,
-    target_location: Coords,
-    damage_dealt: f32,
-    attacker_unit_type: u8,
-    attacker_unit_id: String,
-    attacker_player_id: PlayerId,
-));
-
+deser_as_tuple!(
+    MeleeEvent,
+    (
+        attacker_location: Coords,
+        target_location: Coords,
+        damage_dealt: f32,
+        attacker_unit_type: u8,
+        attacker_unit_id: String,
+        attacker_player_id: PlayerId,
+    )
+);
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct MoveEvent {
@@ -271,15 +275,17 @@ pub struct MoveEvent {
     pub owner: PlayerId,
 }
 
-deser_as_tuple!(MoveEvent, (
-    old_location: Coords,
-    new_location: Coords,
-    desired_next_lcoation: Coords,
-    unit_type: u8,
-    unit_id: String,
-    owner: PlayerId,
-));
-
+deser_as_tuple!(
+    MoveEvent,
+    (
+        old_location: Coords,
+        new_location: Coords,
+        desired_next_lcoation: Coords,
+        unit_type: u8,
+        unit_id: String,
+        owner: PlayerId,
+    )
+);
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct SelfDestructEvent {
@@ -291,15 +297,17 @@ pub struct SelfDestructEvent {
     pub exploding_unit_owner: PlayerId,
 }
 
-deser_as_tuple!(SelfDestructEvent, (
-    source: Coords,
-    targets: Vec<Coords>,
-    damage: f32,
-    exploding_unit_type: u8,
-    exploding_unit_id: String,
-    exploding_unit_owner: PlayerId,
-));
-
+deser_as_tuple!(
+    SelfDestructEvent,
+    (
+        source: Coords,
+        targets: Vec<Coords>,
+        damage: f32,
+        exploding_unit_type: u8,
+        exploding_unit_id: String,
+        exploding_unit_owner: PlayerId,
+    )
+);
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct ShieldEvent {
@@ -312,16 +320,18 @@ pub struct ShieldEvent {
     pub support_owner: PlayerId,
 }
 
-deser_as_tuple!(ShieldEvent, (
-    support_coords: Coords,
-    mobile_coords: Coords,
-    shield_amount: f32,
-    support_type: u8,
-    support_unit_id: String,
-    mobile_unit_id: String,
-    support_owner: PlayerId,
-));
-
+deser_as_tuple!(
+    ShieldEvent,
+    (
+        support_coords: Coords,
+        mobile_coords: Coords,
+        shield_amount: f32,
+        support_type: u8,
+        support_unit_id: String,
+        mobile_unit_id: String,
+        support_owner: PlayerId,
+    )
+);
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct SpawnEvent {
@@ -331,9 +341,12 @@ pub struct SpawnEvent {
     pub owner: PlayerId,
 }
 
-deser_as_tuple!(SpawnEvent, (
-    spawn_location: Coords,
-    spawning_unit_type: u8,
-    spawning_unit_id: String,
-    owner: PlayerId,
-));
+deser_as_tuple!(
+    SpawnEvent,
+    (
+        spawn_location: Coords,
+        spawning_unit_type: u8,
+        spawning_unit_id: String,
+        owner: PlayerId,
+    )
+);

--- a/rust-algo/algo/src/messages/mod.rs
+++ b/rust-algo/algo/src/messages/mod.rs
@@ -1,12 +1,11 @@
-
 //! Rust model of data passed between the game and this algo.
 
 /// Utilities for serializing and deserializing.
 #[macro_use]
 pub mod serde_util;
 
-use serde::Deserialize;
 use enum_iterator::IntoEnumIterator;
+use serde::Deserialize;
 
 /// Model of config data.
 pub mod config;
@@ -23,7 +22,6 @@ pub struct Config {
     pub resources: config::Resources,
 }
 
-
 /// The frame data, received every game frame.
 #[derive(Debug, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
@@ -37,7 +35,6 @@ pub struct FrameData {
     pub events: frame::Events,
 }
 
-
 /// Player 1 or player 2.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, IntoEnumIterator)]
 pub enum PlayerId {
@@ -49,4 +46,3 @@ serde_enum_from_int!(PlayerId, {
     1 => PlayerId::Player1,
     2 => PlayerId::Player2,
 });
-

--- a/rust-algo/algo/src/messages/serde_util.rs
+++ b/rust-algo/algo/src/messages/serde_util.rs
@@ -1,4 +1,3 @@
-
 /// Implement Deserialize that translates integer
 /// constants to enum variants.
 macro_rules! serde_enum_from_int {
@@ -56,11 +55,11 @@ pub trait DeserializeAs: Sized {
 /// Implement `Serialize` for a type by delegating to its
 /// implementation of `DeserializeAs`.
 macro_rules! deser_as {
-    ($t:ty)=>{
+    ($t:ty) => {
         impl<'de> serde::de::Deserialize<'de> for $t {
             fn deserialize<D>(d: D) -> Result<Self, D::Error>
             where
-                D: serde::de::Deserializer<'de>
+                D: serde::de::Deserializer<'de>,
             {
                 use $crate::messages::serde_util::DeserializeAs;
 
@@ -70,7 +69,6 @@ macro_rules! deser_as {
         }
     };
 }
-
 
 /// Allows implementation of `Serialize` through a delegate
 /// data model type, which this type first converts into.
@@ -83,7 +81,7 @@ pub trait SerializeAs: Sized {
 /// Implement `Serialize` for a type by delegating to its
 /// implementation of `SerializeAs`.
 macro_rules! ser_as {
-    ($t:ty)=>{
+    ($t:ty) => {
         impl serde::ser::Serialize for $t {
             fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
             where
@@ -95,9 +93,8 @@ macro_rules! ser_as {
                 <$t as SerializeAs>::Model::serialize(&model, s)
             }
         }
-    }
+    };
 }
-
 
 /// Implement `DeserializeAs` for a struct, by directly
 /// mirroring its named fields into a tuple.
@@ -133,8 +130,8 @@ pub struct RoundNumber(f64);
 
 impl<'de> serde::de::Deserialize<'de> for RoundNumber {
     fn deserialize<D>(d: D) -> Result<Self, D::Error>
-        where
-            D: serde::de::Deserializer<'de>
+    where
+        D: serde::de::Deserializer<'de>,
     {
         use serde::de::{Error, Visitor};
         use std::fmt::{self, Formatter};

--- a/rust-algo/algo/src/pathfinding.rs
+++ b/rust-algo/algo/src/pathfinding.rs
@@ -1,17 +1,10 @@
-
-use crate::{
-    map::*,
-    bounds::*,
-    units::*,
-    coords::*,
-    grid::Grid,
-};
+use crate::{bounds::*, coords::*, grid::Grid, map::*, units::*};
 
 use std::{
-    u32,
-    collections::VecDeque,
     cmp::Ordering,
+    collections::VecDeque,
     fmt::{self, Debug, Formatter, Write},
+    u32,
 };
 
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -21,24 +14,20 @@ enum Node {
     Open {
         visited_idealness: bool,
         pathlength: Option<u32>,
-    }
+    },
 }
 
 impl Debug for Node {
     fn fmt(&self, f: &mut Formatter) -> Result<(), fmt::Error> {
         match self {
-            &Node::Invalid => {
-                f.write_char('I')
-            },
-            &Node::Wall => {
-                f.write_char('W')
-            },
-            &Node::Open {
+            &Node::Invalid => f.write_char('I'),
+            Node::Wall => f.write_char('W'),
+            Node::Open {
                 visited_idealness,
-                pathlength
+                pathlength,
             } => {
                 let mut string = String::new();
-                if visited_idealness {
+                if *visited_idealness {
                     string.push('V');
                 }
                 if let Some(pathlength) = pathlength {
@@ -55,7 +44,7 @@ impl Debug for Node {
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 enum LastDirection {
     Horizontal,
-    Vertical
+    Vertical,
 }
 
 /// Pathfinding from a particular location will fail if that location is blocked by a wall.
@@ -63,7 +52,11 @@ enum LastDirection {
 pub struct StartedAtWall(pub Coords, pub Unit<StructureUnitType>);
 
 /// Attempt to pathfind from a particular tile on a map, to a certain map edge.
-pub fn pathfind(board: &MapState, start: &MapTile, target: MapEdge) -> Result<Vec<Coords>, StartedAtWall> {
+pub fn pathfind(
+    board: &MapState,
+    start: &MapTile,
+    target: MapEdge,
+) -> Result<Vec<Coords>, StartedAtWall> {
     // we cannot pathfind if we start at a wall
     if let Some(wall) = start.wall_unit() {
         return Err(StartedAtWall(start.coords(), wall));
@@ -71,14 +64,15 @@ pub fn pathfind(board: &MapState, start: &MapTile, target: MapEdge) -> Result<Ve
 
     // create the grid of nodes
     let mut grid = Grid::from_generator(|c| {
-        board[c].if_valid()
+        board[c]
+            .if_valid()
             .map(|cell| {
                 if cell.wall_unit().is_some() {
                     Node::Wall
                 } else {
                     Node::Open {
                         visited_idealness: false,
-                        pathlength: None
+                        pathlength: None,
                     }
                 }
             })
@@ -89,7 +83,7 @@ pub fn pathfind(board: &MapState, start: &MapTile, target: MapEdge) -> Result<Ve
     let ideal_tiles = idealness_search(board, start, target, &mut grid);
 
     // validate the pocket
-    validate(board, &mut grid, ideal_tiles);
+    validate(board, &mut grid, &ideal_tiles);
 
     // get the path
     let path = get_path(start.coords(), target, &grid);
@@ -97,7 +91,12 @@ pub fn pathfind(board: &MapState, start: &MapTile, target: MapEdge) -> Result<Ve
     Ok(path)
 }
 
-fn idealness_search(board: &MapState, start: &MapTile, target: MapEdge, grid: &mut Grid<Node>) -> Box<[Coords]> {
+fn idealness_search(
+    board: &MapState,
+    start: &MapTile,
+    target: MapEdge,
+    grid: &mut Grid<Node>,
+) -> Box<[Coords]> {
     // short circuit if start is on the edge
     if MAP_BOUNDS.is_on_edge(target, start.coords()) {
         return Box::new(MAP_BOUNDS.coords_on_edge(target).to_owned());
@@ -112,22 +111,27 @@ fn idealness_search(board: &MapState, start: &MapTile, target: MapEdge, grid: &m
 
     // BFS the pocket
     while let Some(curr) = queue.pop_front() {
-        for neighbor in curr.neighbors().iter().cloned()
+        for neighbor in curr
+            .neighbors()
+            .iter()
+            .cloned()
             .flat_map(|coord| board[coord].if_valid())
             .filter(|cell| cell.wall_unit().is_none())
-            .map(|cell| cell.coords()) {
-
+            .map(|cell| cell.coords())
+        {
             // don't enter an infinite loop
-            match grid.get_mut(neighbor).unwrap() {
-                &mut Node::Open {
+            match *grid.get_mut(neighbor).unwrap() {
+                Node::Open {
                     ref mut visited_idealness,
                     ..
-                } => if *visited_idealness {
-                    continue;
-                } else {
-                    *visited_idealness = true;
-                },
-                _ => unreachable!()
+                } => {
+                    if *visited_idealness {
+                        continue;
+                    } else {
+                        *visited_idealness = true;
+                    }
+                }
+                _ => unreachable!(),
             };
 
             // short circuit if we've reached the edge
@@ -159,16 +163,14 @@ fn idealness_of(coords: Coords, target: MapEdge) -> Result<u32, Coords> {
         } else {
             let coords = [coords.x as u32, coords.y as u32];
             let a = match target {
-                MapEdge::TopLeft | MapEdge::TopRight =>
-                    BOARD_SIZE as u32 * coords[1],
-                MapEdge::BottomLeft | MapEdge::BottomRight =>
-                    BOARD_SIZE as u32 * (BOARD_SIZE as u32 - 1 - coords[1]),
+                MapEdge::TopLeft | MapEdge::TopRight => BOARD_SIZE as u32 * coords[1],
+                MapEdge::BottomLeft | MapEdge::BottomRight => {
+                    BOARD_SIZE as u32 * (BOARD_SIZE as u32 - 1 - coords[1])
+                }
             };
             let b = match target {
-                MapEdge::TopRight | MapEdge::BottomRight =>
-                    coords[0],
-                MapEdge::TopLeft | MapEdge::BottomLeft =>
-                    BOARD_SIZE as u32 - 1 - coords[0]
+                MapEdge::TopRight | MapEdge::BottomRight => coords[0],
+                MapEdge::TopLeft | MapEdge::BottomLeft => BOARD_SIZE as u32 - 1 - coords[0],
             };
             Ok(a + b)
         }
@@ -177,18 +179,17 @@ fn idealness_of(coords: Coords, target: MapEdge) -> Result<u32, Coords> {
     }
 }
 
-fn validate(board: &MapState, grid: &mut Grid<Node>, ideal_tiles: Box<[Coords]>) {
+fn validate(board: &MapState, grid: &mut Grid<Node>, ideal_tiles: &[Coords]) {
     // set the first tiles' pathlength, mark them as validate-visited, and add them to a queue
     let mut queue: VecDeque<Coords> = VecDeque::new();
     for ideal_tile in ideal_tiles.iter().cloned() {
         match grid.get_mut(ideal_tile) {
             Some(&mut Node::Open {
-                ref mut pathlength,
-                ..
+                ref mut pathlength, ..
             }) => {
                 *pathlength = Some(0);
                 queue.push_back(ideal_tile);
-            },
+            }
             Some(&mut Node::Wall) => (),
             bad => unreachable!("{:#?}", bad),
         };
@@ -196,23 +197,25 @@ fn validate(board: &MapState, grid: &mut Grid<Node>, ideal_tiles: Box<[Coords]>)
 
     // BFS the pocket
     while let Some(curr) = queue.pop_front() {
-        let curr_pathlength = match grid.get(curr).unwrap() {
-            &Node::Open {
+        let curr_pathlength = *match grid.get(curr).unwrap() {
+            Node::Open {
                 pathlength: Some(pathlength),
                 ..
             } => pathlength,
-            _ => unreachable!()
+            _ => unreachable!(),
         };
 
-        for neighbor in curr.neighbors().iter().cloned()
+        for neighbor in curr
+            .neighbors()
+            .iter()
+            .cloned()
             .flat_map(|coord| board[coord].if_valid())
             .filter(|cell| cell.wall_unit().is_none())
-            .map(|cell| cell.coords()) {
-
-            match grid.get_mut(neighbor).unwrap() {
-                &mut Node::Open {
-                    ref mut pathlength,
-                    ..
+            .map(|cell| cell.coords())
+        {
+            match *grid.get_mut(neighbor).unwrap() {
+                Node::Open {
+                    ref mut pathlength, ..
                 } => {
                     // don't enter an infinite loop
                     if pathlength.is_none() {
@@ -221,15 +224,14 @@ fn validate(board: &MapState, grid: &mut Grid<Node>, ideal_tiles: Box<[Coords]>)
                         queue.push_back(neighbor);
                     }
                 }
-                _ => unreachable!()
+                _ => unreachable!(),
             };
         }
     }
 }
 
 fn get_path(start: Coords, target: MapEdge, grid: &Grid<Node>) -> Vec<Coords> {
-    let mut path = Vec::new();
-    path.push(start);
+    let mut path = vec![start];
 
     let mut curr = start;
     let mut curr_direction = None;
@@ -256,27 +258,42 @@ fn get_path(start: Coords, target: MapEdge, grid: &Grid<Node>) -> Vec<Coords> {
     path
 }
 
-fn next_move(curr: Coords, target: MapEdge, grid: &Grid<Node>, curr_direction: Option<LastDirection>) -> Option<Coords> {
-    let possible: Vec<(Coords, u32)> = curr.neighbors().iter().cloned()
+fn next_move(
+    curr: Coords,
+    target: MapEdge,
+    grid: &Grid<Node>,
+    curr_direction: Option<LastDirection>,
+) -> Option<Coords> {
+    let possible: Vec<(Coords, u32)> = curr
+        .neighbors()
+        .iter()
+        .cloned()
         .filter(|&neighbor| MAP_BOUNDS.is_in_arena(neighbor))
         .flat_map(|neighbor| match grid.get(neighbor) {
             Some(&Node::Open {
                 pathlength: Some(pathlength),
                 ..
             }) => Some((neighbor, pathlength)),
-            _ => None
+            _ => None,
         })
         .collect();
-    possible.iter().cloned()
+    possible
+        .iter()
+        .cloned()
         .map(|(_, pathlength)| pathlength)
         .min()
-        .map(|best_pathlength| possible.iter().cloned()
-            .filter(|&(_, pathlength)| pathlength == best_pathlength)
-            .map(|(possible, _)| possible)
-            .max_by(|&c1, &c2|
-                compare_by_directional_correctness(curr, c1, c2, curr_direction, target)
-                    .unwrap())
-            .unwrap())
+        .map(|best_pathlength| {
+            possible
+                .iter()
+                .cloned()
+                .filter(|&(_, pathlength)| pathlength == best_pathlength)
+                .map(|(possible, _)| possible)
+                .max_by(|&c1, &c2| {
+                    compare_by_directional_correctness(curr, c1, c2, curr_direction, target)
+                        .unwrap()
+                })
+                .unwrap()
+        })
 }
 
 fn direction_difference(from: Coords, to: Coords) -> Result<LastDirection, [Coords; 2]> {
@@ -289,22 +306,21 @@ fn direction_difference(from: Coords, to: Coords) -> Result<LastDirection, [Coor
     }
 }
 
-fn compare_by_directional_correctness(curr: Coords, c1: Coords, c2: Coords,
-                                      curr_direction: Option<LastDirection>, target: MapEdge)
-                                      -> Result<Ordering, [Coords; 2]> {
-
+fn compare_by_directional_correctness(
+    curr: Coords,
+    c1: Coords,
+    c2: Coords,
+    curr_direction: Option<LastDirection>,
+    target: MapEdge,
+) -> Result<Ordering, [Coords; 2]> {
     let direction1 = direction_difference(curr, c1)?;
     let direction2 = direction_difference(curr, c2)?;
 
     match curr_direction {
         // rule 3: if this is the first movement, they will want to move vertically
         None => match (direction1, direction2) {
-            (LastDirection::Vertical, LastDirection::Horizontal) => {
-                Ok(Ordering::Greater)
-            },
-            (LastDirection::Horizontal, LastDirection::Vertical) => {
-                Ok(Ordering::Less)
-            },
+            (LastDirection::Vertical, LastDirection::Horizontal) => Ok(Ordering::Greater),
+            (LastDirection::Horizontal, LastDirection::Vertical) => Ok(Ordering::Less),
             _ => unreachable!(),
         },
         Some(curr_direction) => {
@@ -312,10 +328,10 @@ fn compare_by_directional_correctness(curr: Coords, c1: Coords, c2: Coords,
             match (curr_direction != direction1, curr_direction != direction2) {
                 (true, false) => {
                     return Ok(Ordering::Greater);
-                },
+                }
                 (false, true) => {
                     return Ok(Ordering::Less);
-                },
+                }
                 _ => (),
             };
 

--- a/rust-algo/example/src/main.rs
+++ b/rust-algo/example/src/main.rs
@@ -1,10 +1,6 @@
-
 extern crate algo;
 
-use algo::{
-    prelude::*,
-    pathfinding::StartedAtWall,
-};
+use algo::{pathfinding::StartedAtWall, prelude::*};
 
 fn main() {
     run_game_loop(ExampleAlgo);
@@ -18,12 +14,7 @@ impl GameLoop for ExampleAlgo {
         // callback to make a move in the game
 
         // try to place as many of four walls as possible
-        for &wall_coord in &[
-            xy(12, 5),
-            xy(13, 5),
-            xy(14, 5),
-            xy(15, 5),
-        ] {
+        for &wall_coord in &[xy(12, 5), xy(13, 5), xy(14, 5), xy(15, 5)] {
             map[wall_coord].try_spawn(StructureUnitType::Wall);
         }
 
@@ -31,21 +22,21 @@ impl GameLoop for ExampleAlgo {
         let scout_coord_1 = xy(6, 7);
         let scout_coord_2 = xy(21, 7);
 
-        if map[scout_coord_1].can_spawn(MobileUnitType::Scout, 2).yes() &&
-            map[scout_coord_2].can_spawn(MobileUnitType::Scout, 2).yes()
+        if map[scout_coord_1].can_spawn(MobileUnitType::Scout, 2).yes()
+            && map[scout_coord_2].can_spawn(MobileUnitType::Scout, 2).yes()
         {
             for _ in 0..2 {
-                map[scout_coord_1].spawn(MobileUnitType::Scout)
+                map[scout_coord_1]
+                    .spawn(MobileUnitType::Scout)
                     .expect("Unexpected spawn failure");
-                map[scout_coord_2].spawn(MobileUnitType::Scout)
+                map[scout_coord_2]
+                    .spawn(MobileUnitType::Scout)
                     .expect("Unexpected spawn failure");
             }
         }
 
         // if our cores are low, try to delete a Structure
-        if map.frame_data().p1_stats.cores < 5.0 &&
-            map[xy(5, 5)].can_remove_structure().yes()
-        {
+        if map.frame_data().p1_stats.cores < 5.0 && map[xy(5, 5)].can_remove_structure().yes() {
             map[xy(5, 5)].remove_structure().unwrap();
         }
 
@@ -54,11 +45,10 @@ impl GameLoop for ExampleAlgo {
         match map.pathfind(move_from, MapEdge::BottomRight) {
             Ok(path) => {
                 eprintln!("Path from [13, 27] = {:?}", path)
-            },
+            }
             Err(StartedAtWall(_, unit)) => {
                 eprintln!("Enemy slot [13, 27] is blocked by {:?}", unit);
             }
-
         }
     }
 }

--- a/rust-algo/pathtest/src/main.rs
+++ b/rust-algo/pathtest/src/main.rs
@@ -1,4 +1,3 @@
-
 extern crate algo;
 extern crate serde_json;
 
@@ -8,7 +7,7 @@ use std::io::stdin;
 use std::io::BufRead;
 
 fn main() {
-    let mut reader = GameDataReader::new();
+    let mut reader = GameDataReader::default();
     loop {
         let map = reader.next_turn_map().unwrap();
         let start: [f32; 2] = {

--- a/rust-algo/starter-algo/src/main.rs
+++ b/rust-algo/starter-algo/src/main.rs
@@ -1,4 +1,3 @@
-
 #[macro_use]
 extern crate algo;
 extern crate rand;
@@ -11,42 +10,31 @@ fn main() {
 }
 
 const STRUCTURE_LOCATIONS_C: &[Coords] = &[
-   xy!(8, 11),
-   xy!(9, 11),
-   xy!(7, 10),
-   xy!(7, 9),
-   xy!(7, 8),
-   xy!(8, 7),
-   xy!(9, 7),
+    xy!(8, 11),
+    xy!(9, 11),
+    xy!(7, 10),
+    xy!(7, 9),
+    xy!(7, 8),
+    xy!(8, 7),
+    xy!(9, 7),
 ];
 
 const STRUCTURE_LOCATIONS_1: &[Coords] = &[
-   xy!(17, 11),
-   xy!(18, 11),
-   xy!(18, 10),
-   xy!(18, 9),
-   xy!(18, 8),
-   xy!(17, 7),
-   xy!(18, 7),
-   xy!(19, 7),
+    xy!(17, 11),
+    xy!(18, 11),
+    xy!(18, 10),
+    xy!(18, 9),
+    xy!(18, 8),
+    xy!(17, 7),
+    xy!(18, 7),
+    xy!(19, 7),
 ];
 
-const STRUCTURE_LOCATIONS_DOTS: &[Coords] = &[
-   xy!(11, 7),
-   xy!(13, 9),
-   xy!(15, 11),
-];
+const STRUCTURE_LOCATIONS_DOTS: &[Coords] = &[xy!(11, 7), xy!(13, 9), xy!(15, 11)];
 
-const DEFENSIVE_TURRET_LOCATIONS: &[Coords] = &[
-   xy!(0, 13),
-   xy!(27, 13),
-];
+const DEFENSIVE_TURRET_LOCATIONS: &[Coords] = &[xy!(0, 13), xy!(27, 13)];
 
-const DEFENSIVE_SUPPORT_LOCATIONS: &[Coords] = &[
-   xy!(3, 11),
-   xy!(4, 11),
-   xy!(5, 11),
-];
+const DEFENSIVE_SUPPORT_LOCATIONS: &[Coords] = &[xy!(3, 11), xy!(4, 11), xy!(5, 11)];
 
 /// Rust implementation of the standard starter algo.
 struct StarterAlgo;
@@ -57,8 +45,10 @@ impl GameLoop for StarterAlgo {
     }
 
     fn on_turn(&mut self, _: Arc<Config>, map: &MapState) {
-        eprintln!("Performing turn {} of your custom algo strategy",
-                  map.frame_data().turn_info.turn_number);
+        eprintln!(
+            "Performing turn {} of your custom algo strategy",
+            map.frame_data().turn_info.turn_number
+        );
         build_c1_logo(map);
         build_defenses(map);
         deploy_attackers(map);
@@ -99,8 +89,8 @@ fn build_defenses(map: &MapState) {
     }
 
     /*
-    Lastly lets build supports in random locations. 
-    Building randomly is not effective, but we'll leave 
+    Lastly lets build supports in random locations.
+    Building randomly is not effective, but we'll leave
     it to you to figure out better strategies.
 
     First we get all locations on the bottom half of the map
@@ -118,8 +108,7 @@ fn build_defenses(map: &MapState) {
         }
     }
     thread_rng().shuffle(&mut possible_spawn_points);
-    while map.number_affordable(StructureUnitType::Support) > 0 &&
-        possible_spawn_points.len() > 0
+    while map.number_affordable(StructureUnitType::Support) > 0 && !possible_spawn_points.is_empty()
     {
         let coords = possible_spawn_points.pop().unwrap();
         map[coords].try_spawn(StructureUnitType::Support);
@@ -164,8 +153,18 @@ fn deploy_attackers(map: &MapState) {
     list of those locations.
      */
     let mut friendly_edges = Vec::new();
-    friendly_edges.extend(MAP_BOUNDS.coords_on_edge(MapEdge::BottomLeft).iter().cloned());
-    friendly_edges.extend(MAP_BOUNDS.coords_on_edge(MapEdge::BottomRight).iter().cloned());
+    friendly_edges.extend(
+        MAP_BOUNDS
+            .coords_on_edge(MapEdge::BottomLeft)
+            .iter()
+            .cloned(),
+    );
+    friendly_edges.extend(
+        MAP_BOUNDS
+            .coords_on_edge(MapEdge::BottomRight)
+            .iter()
+            .cloned(),
+    );
 
     /*
     While we have remaining bits to spend lets send out interceptors randomly.


### PR DESCRIPTION
In rust, there is a commonly used tool called Clippy which helps reinforce rust idioms/customs. I just implemented almost all of the things it said, such as using From rather than Into, and adding Defaults for things.
Another tool is fmt, which just formats your code nicely, the same as everywhere else.