### PR TITLE
Correctly update costs when upgrading

### DIFF
--- a/python-algo/gamelib/unit.py
+++ b/python-algo/gamelib/unit.py
@@ -72,7 +72,7 @@ class GameUnit:
         self.max_health = type_config.get("startHealth", self.max_health)
         self.shieldPerUnit = type_config.get("shieldPerUnit", self.shieldPerUnit)
         self.shieldBonusPerY = type_config.get("shieldBonusPerY", self.shieldBonusPerY)
-        self.cost = [type_config.get("cost1", 0) + self.cost[0], type_config.get("cost2", 0) + self.cost[1]]
+        self.cost = [type_config.get("cost1", self.cost[0]) + self.cost[0], type_config.get("cost2", self.cost[1]) + self.cost[1]]
         self.upgraded = True
 
 


### PR DESCRIPTION
When a unit didn't have a specific upgrade cost (WALL and SUPPORT) the cost wouldn't be updated after upgrading. This caused the costs for WALL and SUPPORT to stay at [1, 0] and [4, 0] respectievely instead of the correct [2, 0] and [8, 0]. Only TURRET was updated correctly as the config has a separate upgrade value (so it went from [2, 0] to [6, 0]).